### PR TITLE
fix: change email subject

### DIFF
--- a/utilities/email/templates/new_reservation.js
+++ b/utilities/email/templates/new_reservation.js
@@ -3,7 +3,7 @@ import {
   convert_space_reservations_string
 } from '../template_utils.js'
 
-export const subject = '【學生會】預約成功通知'
+export const subject = '【學生會】預約驗證通知'
 export const html = async (reservation) => {
   const space_reservations_string = await convert_space_reservations_string(reservation.space_reservations)
   const item_reservations_string = await convert_item_reservations_string(reservation.item_reservations)


### PR DESCRIPTION
更改新增預約送出時，所寄送的 email 主旨，從「預約成功通知」改為「預約驗證通知」，以免誤導使用者。

（進行驗證之前的預約紀錄，不被視為正式的預約紀錄，而是暫時紀錄的狀態）