### PR TITLE
Fix: PUT /reserve allow over reserve

### DIFF
--- a/routes/reserve/post_reserve.js
+++ b/routes/reserve/post_reserve.js
@@ -384,6 +384,7 @@ router.post('/reserve', [
     }
   }
 
+  // TODO: Need refactor, use function in validate_item_reservation.js
   // Check if DB has enough items to be reserved
   let db_item_check
   let max_quantity

--- a/routes/reserve/put_reserve.js
+++ b/routes/reserve/put_reserve.js
@@ -368,7 +368,7 @@ router.put('/reserve/:reservation_id', [
   console.log('remove_item_reservations: ', remove_item_reservations) // debug
 
   // check items not all reserved
-  if (await isRemainItemEnough(add_item_reservations)) {
+  if (!(await isRemainItemEnough(add_item_reservations))) {
     res
       .status(400)
       .json(

--- a/utilities/reserve/validate_item_reservation.js
+++ b/utilities/reserve/validate_item_reservation.js
@@ -137,8 +137,8 @@ export async function isRemainItemEnough (received_item_reserved_time) {
 
     // 檢查總預約數量是否超過限制
     if (total_reserved_quantity > max_quantity.quantity) {
-      return true
+      return false
     }
   }
-  return false
+  return true
 }


### PR DESCRIPTION
修復PUT /reserve中，使用重複的物品預約，可以預約超過物品的上限
validate_item_reservation.js 裡的檢查function是從 post_reserve.js 裡複製來的